### PR TITLE
fix-relevant-business

### DIFF
--- a/src/business/dto/public-business-filter.dto.ts
+++ b/src/business/dto/public-business-filter.dto.ts
@@ -1,7 +1,20 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsNumber, IsString } from 'class-validator';
 import { Type } from 'class-transformer';
+import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
 import { PaginationDto } from 'src/shared/pagination/dto/pagination.dto';
+
+
+export enum BusinessSortOption {
+  RECENT   = 'recent',
+  RATED    = 'rated',
+  REVIEWS  = 'reviews',
+  RELEVANT = 'relevant',
+}
+
+export enum SortDirection {
+  ASC = 'ASC',
+  DESC = 'DESC',
+}
 
 export class PublicBusinessFilterDto extends PaginationDto {
 
@@ -21,4 +34,16 @@ export class PublicBusinessFilterDto extends PaginationDto {
   @Type(() => Number)
   @IsNumber()
   id_tag?: number; 
+
+  @ApiPropertyOptional({ description: 'Ordenar por: recent, rated o reviews' })
+  @IsOptional()
+  @IsEnum(BusinessSortOption, {
+    message: 'sortBy debe ser un valor válido: recent, rated o reviews',
+  })
+  sortBy?: BusinessSortOption;
+
+  @ApiPropertyOptional({ description: 'Dirección de ordenamiento: ASC o DESC' })
+  @IsOptional()
+  @IsEnum(SortDirection)
+  sortDirection?: SortDirection;
 }

--- a/src/business/services/business.service.ts
+++ b/src/business/services/business.service.ts
@@ -1,28 +1,27 @@
+
 import {
   BadRequestException,
+  ConflictException,
+  ForbiddenException,
   Injectable,
   InternalServerErrorException,
   NotFoundException,
-  ForbiddenException,
-  ConflictException,
 } from '@nestjs/common';
-import { In, MoreThanOrEqual, Not} from 'typeorm';
-import { Business, BusinessStatus } from '../../shared/entities/business.entity';
-import { CreateBusinessDto } from '../dto/create-business.dto';
-import { UpdateBusinessDto } from '../dto/update-business.dto';
-import { User } from 'src/shared/entities/user.entity';
-import { Tag } from '../../shared/entities/tags.entity';
 import { MailService } from 'src/mail/mail.service';
-import { FindOptionsWhere, ILike } from 'typeorm';
-import { GetBusinessesFilterDto } from '../dto/get-businesses-filter.dto';
-import { createPaginationResponse } from '../../shared/pagination/pagination.helper';
-import { PaginationDto } from '../../shared/pagination/dto/pagination.dto';
+import { User } from 'src/shared/entities/user.entity';
 import { BusinessRepository } from 'src/shared/repositories/business.repository';
 import { CategoryRepository } from 'src/shared/repositories/category.repository';
-import { TagsRepository } from 'src/shared/repositories/tags.repository';
-import { PublicBusinessFilterDto } from '../dto/public-business-filter.dto';
 import { RolRepository } from 'src/shared/repositories/rol.repository';
+import { TagsRepository } from 'src/shared/repositories/tags.repository';
 import { UserRepository } from 'src/shared/repositories/user.repository';
+import { FindOptionsWhere, ILike, In, MoreThanOrEqual, Not } from 'typeorm';
+import { Business, BusinessStatus } from '../../shared/entities/business.entity';
+import { Tag } from '../../shared/entities/tags.entity';
+import { createPaginationResponse } from '../../shared/pagination/pagination.helper';
+import { CreateBusinessDto } from '../dto/create-business.dto';
+import { GetBusinessesFilterDto } from '../dto/get-businesses-filter.dto';
+import { BusinessSortOption, PublicBusinessFilterDto } from '../dto/public-business-filter.dto';
+import { UpdateBusinessDto } from '../dto/update-business.dto';
 
 
 @Injectable()
@@ -43,8 +42,21 @@ export class BusinessService {
 
   //Metodos publicos
   async findAllPublic(filterDto: PublicBusinessFilterDto) {
-    const { page = 1, limit = 10, id_category, id_tag, search } = filterDto;
+    const { page = 1, limit = 50, id_category, id_tag, search, sortBy, sortDirection = 'DESC' } = filterDto;
     const skip = (page - 1) * limit;
+
+    if (!sortBy || sortBy === BusinessSortOption.RELEVANT) {
+      const [businesses, total] = await this.businessRepository
+        .findPublicWithRelevanceScore({ skip, take: limit, id_category, id_tag, search });
+
+      if (total === 0)
+        throw new NotFoundException('No hay negocios disponibles en este momento.');
+
+      return createPaginationResponse(
+        businesses.map(b => this.sanitizePublicBusiness(b)),
+        total, page, limit,
+      );
+    }
 
     const whereConditions: FindOptionsWhere<Business> = {
       status: BusinessStatus.ACTIVE,
@@ -62,10 +74,20 @@ export class BusinessService {
       whereConditions.tags = { id_tags: id_tag };
     }
 
+
+    let orderClause: any = { createdAt: sortDirection };
+
+    if (sortBy === BusinessSortOption.RATED) {
+      orderClause = { average_rating: sortDirection, total_reviews: sortDirection };
+    } else if (sortBy === BusinessSortOption.REVIEWS) {
+      orderClause = { total_reviews: sortDirection, average_rating: sortDirection };
+    } else if (sortBy === BusinessSortOption.RECENT) {
+      orderClause = { createdAt: sortDirection };
+    }
     const [businesses, total] = await this.businessRepository.findAndCount({
       where: whereConditions,
       relations: ['category', 'tags', 'certifications'],
-      order: { createdAt: 'DESC' },
+      order: orderClause,
       skip: skip,
       take: limit,
     });
@@ -139,7 +161,7 @@ export class BusinessService {
 
   async findAllForAdmin(filters: GetBusinessesFilterDto) {
     
-    const { status, isActive, id_category, id_tag, search, page = 1, limit = 10 } = filters;
+    const { status, isActive, id_category, id_tag, search, sortBy, sortDirection = 'DESC', page = 1, limit = 10 } = filters;
     const skip = (page - 1) * limit;
     const whereCondition: FindOptionsWhere<Business> = {};
 
@@ -163,10 +185,20 @@ export class BusinessService {
       whereCondition.tags = { id_tags: id_tag };
     }
 
+    let orderClause: any = { createdAt: sortDirection };
+
+    if (sortBy === BusinessSortOption.RATED) {
+      orderClause = { average_rating: sortDirection, total_reviews: sortDirection };
+    } else if (sortBy === BusinessSortOption.REVIEWS) {
+      orderClause = { total_reviews: sortDirection, average_rating: sortDirection };
+    } else if (sortBy === BusinessSortOption.RECENT) {
+      orderClause = { createdAt: sortDirection };
+    }
+
     const [businesses, total] = await this.businessRepository.findAndCount({
       where: whereCondition,
       relations: ['user', 'category', 'tags', 'certifications'],
-      order: { createdAt: 'DESC' },
+      order: orderClause,
       skip,
       take: limit,
     });

--- a/src/follow/services/follow.service.ts
+++ b/src/follow/services/follow.service.ts
@@ -1,17 +1,18 @@
+
 import {
-  Injectable,
-  NotFoundException,
-  ConflictException,
   BadRequestException,
-  ForbiddenException,
+  ConflictException,
+  Injectable,
+  NotFoundException
 } from '@nestjs/common';
-import { BusinessRepository } from 'src/shared/repositories/business.repository';
 import { Business, BusinessStatus } from 'src/shared/entities/business.entity';
-import { FollowRepository } from 'src/shared/repositories/follow.repository';
 import { PaginationDto } from 'src/shared/pagination/dto/pagination.dto';
 import { createPaginationResponse } from 'src/shared/pagination/pagination.helper';
-import { TagsRepository } from 'src/shared/repositories/tags.repository';
+import { BusinessRepository } from 'src/shared/repositories/business.repository';
 import { CategoryRepository } from 'src/shared/repositories/category.repository';
+import { FollowRepository } from 'src/shared/repositories/follow.repository';
+import { TagsRepository } from 'src/shared/repositories/tags.repository';
+import { MoreThanOrEqual } from 'typeorm';
 
 
 @Injectable()
@@ -163,21 +164,26 @@ export class FollowsService {
   }
 
   async getMostFollowedBusinesses(paginationDto: PaginationDto) {
-    const { page = 1, limit = 10 } = paginationDto;
-    const skip = (page - 1) * limit;
-    const [businesses, total] = await this.businessRepository.findAndCount({
-      where: { status: BusinessStatus.ACTIVE, isActive: true },
-      order: { followers_count: 'DESC' },
-      skip,
-      take: 5,
-    });
+    const businesses = await this.businessRepository.find({
+    where: { 
+      status: BusinessStatus.ACTIVE, 
+      isActive: true,
+      followers_count: MoreThanOrEqual(1),
+    },
+    relations: ['category', 'tags', 'certifications'],
+    order: { 
+      followers_count: 'DESC',
+      createdAt: 'DESC'
+    },
+    take: 5,
+  });
 
-    if (total === 0) {
-      throw new NotFoundException('No hay negocios disponibles en este momento.');
-    }
-
-
-    const sanitizedBusinesses = businesses.map(b => this.sanitizePublicBusiness(b));
-    return createPaginationResponse(sanitizedBusinesses, total, page, limit);
+  if (businesses.length === 0) {
+    throw new NotFoundException('Aún no hay negocios con seguidores para mostrar.');
   }
+
+  return businesses.map(b => this.sanitizePublicBusiness(b));
+  
+  }
+  
 }

--- a/src/shared/repositories/business.repository.ts
+++ b/src/shared/repositories/business.repository.ts
@@ -7,4 +7,43 @@ export class BusinessRepository extends Repository<Business> {
   constructor(dataSource: DataSource) {
     super(Business, dataSource.createEntityManager());
   }
+
+  async findPublicWithRelevanceScore(opts: {
+    skip: number;
+    take: number;
+    id_category?: number;
+    id_tag?: number;
+    search?: string;
+  }): Promise<[Business[], number]> {
+    const qb = this.createQueryBuilder('b')
+      .leftJoinAndSelect('b.category',       'category')
+      .leftJoinAndSelect('b.tags',           'tags')
+      .leftJoinAndSelect('b.certifications', 'certifications')
+      .where('b.status = :status',   { status: 'Active' })
+      .andWhere('b.isActive = :isActive', { isActive: true });
+
+    if (opts.id_category) {
+      qb.andWhere('category.id_category = :id_category', { id_category: opts.id_category });
+    }
+    if (opts.id_tag) {
+      qb.andWhere('tags.id_tags = :id_tag', { id_tag: opts.id_tag });
+    }
+    if (opts.search) {
+      qb.andWhere('b.businessName ILIKE :search', { search: `%${opts.search}%` });
+    }
+
+    qb.addSelect(`
+      (
+        (CAST(b.average_rating  AS FLOAT) / 5.0) * 0.40 +
+        (LN(CAST(b.total_reviews   AS FLOAT) + 1) / LN(51)) * 0.25 +
+        (LN(CAST(b.followers_count AS FLOAT) + 1) / LN(51)) * 0.25 +
+        (1.0 / (1.0 + EXTRACT(EPOCH FROM (NOW() - b."createdAt")) / 7776000.0)) * 0.10
+      )
+    `, 'relevance_score')
+      .orderBy('relevance_score', 'DESC')
+      .skip(opts.skip)
+      .take(opts.take);
+
+    return qb.getManyAndCount();
+  }
 }


### PR DESCRIPTION
### DESCRIPCION

Se agregó un nuevo sistema de ordenamiento por relevancia para negocios públicos, incorporando la opción `RELEVANT` y un cálculo de score en SQL basado en calificación, reseñas, seguidores y recencia. Además, `findAllPublic` ahora utiliza esta lógica por defecto y se aumentó el límite de resultados de 10 a 50. También se corrigió el ordenamiento en `findAllForAdmin`, ya que el `sort` configurado estaba siendo ignorado por una mala estructura en la cláusula `order`.
